### PR TITLE
Adding gang scheduling example

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -249,7 +249,7 @@ func NewConfigFactory(args *ConfigFactoryArgs) Configurator {
 	}
 	schedulerCache := internalcache.New(30*time.Second, stopEverything)
 	// TODO(bsalamat): config files should be passed to the framework.
-	framework, err := framework.NewFramework(args.Registry, nil)
+	framework, err := framework.NewFramework(args.Registry, nil, args.Client)
 	if err != nil {
 		klog.Fatalf("error initializing the scheduling framework: %v", err)
 	}

--- a/pkg/scheduler/framework/plugins/examples/gang/BUILD
+++ b/pkg/scheduler/framework/plugins/examples/gang/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["gang.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/examples/gang",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/v1alpha1/context.go
+++ b/pkg/scheduler/framework/v1alpha1/context.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	"errors"
 	"sync"
+
+	clientset "k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -39,12 +41,14 @@ type ContextKey string
 type PluginContext struct {
 	mx      sync.RWMutex
 	storage map[ContextKey]ContextData
+	client  clientset.Interface
 }
 
 // NewPluginContext initializes a new PluginContext and returns its pointer.
-func NewPluginContext() *PluginContext {
+func NewPluginContext(client clientset.Interface) *PluginContext {
 	return &PluginContext{
 		storage: make(map[ContextKey]ContextData),
+		client:  client,
 	}
 }
 
@@ -91,4 +95,9 @@ func (c *PluginContext) RLock() {
 // RUnlock releases PluginContext read lock.
 func (c *PluginContext) RUnlock() {
 	c.mx.RUnlock()
+}
+
+// Client returns the instance of clientset.Interface
+func (c *PluginContext) Client() clientset.Interface {
+	return c.client
 }

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 
 	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
 
@@ -160,4 +161,8 @@ type FrameworkHandle interface {
 	// a pod finishes "Reserve" point. There is no guarantee that the information
 	// remains unchanged in the binding phase of scheduling.
 	NodeInfoSnapshot() *internalcache.NodeInfoSnapshot
+
+	// Client returns the k8s client interface passed in at the creation time
+	// of the instance of the framework.
+	Client() clientset.Interface
 }

--- a/pkg/scheduler/plugins/examples/BUILD
+++ b/pkg/scheduler/plugins/examples/BUILD
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "multipoint.go",
+        "prebind.go",
+        "stateful.go",
+        "gang.go",
+    ],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/plugins/examples",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/plugins/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/plugins/examples/gang.go
+++ b/pkg/scheduler/plugins/examples/gang.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examples
+
+import (
+	"fmt"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	batch "k8s.io/kubernetes/pkg/apis/batch"
+	plugins "k8s.io/kubernetes/pkg/scheduler/plugins/v1alpha1"
+)
+
+// GangSchedulingPlugin is an example of a plugin that implements permit for gang scheduling
+type GangSchedulingPlugin struct {
+	backoff wait.Backoff
+}
+
+//counterAddType indicates which of the 3 bins to operate on
+type counterAddType int
+
+const (
+	rejected       counterAddType = 0
+	accepted       counterAddType = 1
+	waiting        counterAddType = 2
+	gangAnnotation string         = "k8s.gang.io"
+)
+
+//GangCounter is the map which keeps track of which pods were seen
+//It is a 2 level map, counterAddType being the first level and podId being the second level key
+type GangCounter struct {
+	pile map[counterAddType]map[string]bool
+}
+
+// NewGangCounter initializes a new GangCounter and returns it.
+func NewGangCounter() *GangCounter {
+	return &GangCounter{
+		pile: map[counterAddType]map[string]bool{},
+	}
+}
+
+var _ = plugins.PermitPlugin(GangSchedulingPlugin{})
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (mc GangSchedulingPlugin) Name() string {
+	return "gang-scheduling-plugin"
+}
+
+//addPodUIDToCounter adds the pod UID to a counterAddType bin for the given key (job UID).
+//This is an atomic operation.
+func (mc GangSchedulingPlugin) addPodUIDToCounter(ps plugins.PluginSet, key string, podUID string, opType counterAddType) error {
+	ps.Data().Ctx.Mx.RLock()
+	defer ps.Data().Ctx.Mx.RUnlock()
+	//Add a new counter if it does not exist for this key
+	if _, e := ps.Data().Ctx.Read(plugins.ContextKey(key)); e != nil {
+		ps.Data().Ctx.Write(plugins.ContextKey(key), NewGangCounter())
+	}
+	c, err := ps.Data().Ctx.Read(plugins.ContextKey(key))
+	if err != nil {
+		return err
+	}
+	counter := c.(*GangCounter)
+	//Get a map for this counterAddType bin
+	mapToConsider, present := counter.pile[opType]
+	//Add a new map if not present yet
+	if !present {
+		counter.pile[opType] = map[string]bool{}
+		mapToConsider = counter.pile[opType]
+	}
+	if _, present := mapToConsider[podUID]; !present {
+		mapToConsider[podUID] = true
+	}
+
+	ps.Data().Ctx.Write(plugins.ContextKey(key), counter)
+	return nil
+}
+
+//getCount returns the pod UIDs from all counterAddType bins for the given key (job UID).
+//This is an atomic operation.
+func (mc GangSchedulingPlugin) getCount(ps plugins.PluginSet, key string) (*GangCounter, error) {
+	ps.Data().Ctx.Mx.RLock()
+	defer ps.Data().Ctx.Mx.RUnlock()
+	//Add a new counter if it does not exist for this key
+	if _, e := ps.Data().Ctx.Read(plugins.ContextKey(key)); e != nil {
+		ps.Data().Ctx.Write(plugins.ContextKey(key), NewGangCounter())
+	}
+	c, err := ps.Data().Ctx.Read(plugins.ContextKey(key))
+	if err != nil {
+		return nil, err
+	}
+
+	counter := c.(*GangCounter)
+	return counter, nil
+}
+
+//getJobFromPod returns the parent job for the pod if it exists
+func (mc GangSchedulingPlugin) getJobFromPod(ps plugins.PluginSet, pod *v1.Pod) (*batchv1.Job, error) {
+	// If pod is not part of a job, return true as it's not part of a gang
+	ownerReference := metav1.GetControllerOf(pod)
+	if ownerReference == nil {
+		return nil, fmt.Errorf("Owner reference of pod with ID %v is nil", pod.UID)
+	}
+	// Check if it is part of a job for now.
+	// Get jobClient
+	batchKind := batch.Kind("Job")
+
+	if ownerReference.Kind != batchKind.Kind {
+		return nil, fmt.Errorf("Kind of owner reference of pod with ID %v is not a job", pod.UID)
+	}
+
+	job, err := ps.Data().Client.BatchV1().Jobs(pod.Namespace).Get(ownerReference.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if job.UID != ownerReference.UID {
+		return nil, fmt.Errorf("ID of job is not the same as owner reference for pod with id %v", pod.UID)
+	}
+
+	//Check annotation if this is supposed to be gang scheduled
+	if _, e := job.Annotations[gangAnnotation]; !e {
+		return nil, fmt.Errorf("Job not marked to be gang scheduled")
+	}
+
+	return job, nil
+}
+
+//cleanIfDone cleans the map if all pods in the gang have already been scheduled
+func (mc GangSchedulingPlugin) cleanIfDone(ps plugins.PluginSet, pod *v1.Pod) error {
+	ps.Data().Ctx.Mx.RLock()
+	defer ps.Data().Ctx.Mx.RUnlock()
+	job, err := mc.getJobFromPod(ps, pod)
+	if err != nil {
+		return nil
+	}
+	c, err := ps.Data().Ctx.Read(plugins.ContextKey(string(job.UID)))
+	if err != nil {
+		return err
+	}
+	counter := c.(*GangCounter)
+
+	if int32(len(counter.pile[accepted])) == *job.Spec.Parallelism {
+		// Delete this key
+		ps.Data().Ctx.Delete(plugins.ContextKey(string(job.UID)))
+	}
+
+	return nil
+}
+
+// Permit is invoked by the framework at "permit" extension point.
+func (mc GangSchedulingPlugin) Permit(ps plugins.PluginSet, pod *v1.Pod, nodeName string) (bool, error) {
+
+	for true {
+		//Check if the pod should be rejected
+		reject, err := mc.ShouldReject(ps, pod)
+		if err != nil || reject {
+			return false, err
+		}
+
+		//Check if the pod should wait for other pods in the gang
+		wait, err := mc.ShouldWait(ps, pod)
+		if err != nil {
+			return false, err
+		}
+		if wait {
+			//Sleep timeout reached
+			if mc.backoff.Steps == 1 {
+				return false, fmt.Errorf("Timed out waiting for the gang to be scheduled")
+			}
+			//Sleep with a backoff
+			time.Sleep(mc.backoff.Step())
+			continue
+		}
+
+		//Check if the pod should be accepted. In this case ShouldAccept always returns true
+		accept, err := mc.ShouldAccept(ps, pod)
+		if err != nil || !accept {
+			return false, err
+		}
+
+		//Clean the map if everything in the gang is scheduled.
+		mc.cleanIfDone(ps, pod)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ShouldReject returns true if any pod in the gang has been rejected.
+func (mc GangSchedulingPlugin) ShouldReject(ps plugins.PluginSet, pod *v1.Pod) (bool, error) {
+	// For the owner referenced job, if any pod has been rejected
+	// Here we assume that the same pod won't be called in ShouldReject
+	job, err := mc.getJobFromPod(ps, pod)
+	if err != nil {
+		// Don't return the error as we want to schedule the pod if it's not part of a job
+		return false, nil
+	}
+	//Check if any pod has been rejected
+	counter, err := mc.getCount(ps, string(job.UID))
+	if err != nil {
+		return false, err
+	}
+	// if rejected > 1, return true. Else return false
+	if len(counter.pile[rejected]) >= 1 {
+		// Add pod to the rejected pile
+		mc.addPodUIDToCounter(ps, string(job.UID), string(pod.UID), rejected)
+		return true, fmt.Errorf("One pod in the gang has been rejected")
+	}
+
+	return false, nil
+}
+
+// ShouldWait returns true if any pod in the gang has not been seen yet.
+func (mc GangSchedulingPlugin) ShouldWait(ps plugins.PluginSet, pod *v1.Pod) (bool, error) {
+	// Get the job
+	job, err := mc.getJobFromPod(ps, pod)
+	if err != nil {
+		// Don't return the error as we want to schedule the pod if it's not part of a job
+		return false, nil
+	}
+	counter, err := mc.getCount(ps, string(job.UID))
+	if err != nil {
+		return false, err
+	}
+
+	//Number of pods in gang = job.Parallelism
+	//if rejected == 0, waiting < #replicas, return true, else false
+	if len(counter.pile[rejected]) == 0 && int32(len(counter.pile[waiting])) < *job.Spec.Parallelism {
+		// Add pod to the waiting pile
+		mc.addPodUIDToCounter(ps, string(job.UID), string(pod.UID), waiting)
+		return true, nil
+	}
+	return false, nil
+}
+
+// ShouldAccept returns true in all cases.
+func (mc GangSchedulingPlugin) ShouldAccept(ps plugins.PluginSet, pod *v1.Pod) (bool, error) {
+	// Get the job
+	job, err := mc.getJobFromPod(ps, pod)
+	if err != nil {
+		// Don't return the error as we want to schedule the pod if it's not part of a job
+		return true, nil
+	}
+	// Add pod to the accepted pile
+	mc.addPodUIDToCounter(ps, string(job.UID), string(pod.UID), accepted)
+	return true, nil
+}
+
+// NewGangSchedulingPlugin initializes a new plugin and returns it.
+func NewGangSchedulingPlugin(failureThreshold int) *GangSchedulingPlugin {
+	return &GangSchedulingPlugin{
+		backoff: wait.Backoff{
+			Duration: 1 * time.Second,
+			Factor:   1, // try every second
+			Steps:    failureThreshold,
+		},
+	}
+}

--- a/pkg/scheduler/plugins/registrar.go
+++ b/pkg/scheduler/plugins/registrar.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	plugins "k8s.io/kubernetes/pkg/scheduler/plugins/v1alpha1"
+)
+
+// DefaultPluginSet is the default plugin registrar used by the default scheduler.
+type DefaultPluginSet struct {
+	data           *plugins.PluginData
+	reservePlugins []plugins.ReservePlugin
+	prebindPlugins []plugins.PrebindPlugin
+	permitPlugins  []plugins.PermitPlugin
+}
+
+var _ = plugins.PluginSet(&DefaultPluginSet{})
+
+// ReservePlugins returns a slice of default reserve plugins.
+func (r *DefaultPluginSet) ReservePlugins() []plugins.ReservePlugin {
+	return r.reservePlugins
+}
+
+// PrebindPlugins returns a slice of default prebind plugins.
+func (r *DefaultPluginSet) PrebindPlugins() []plugins.PrebindPlugin {
+	return r.prebindPlugins
+}
+
+// PermitPlugins returns a slice of default permit plugins.
+func (r *DefaultPluginSet) PermitPlugins() []plugins.PermitPlugin {
+	return r.permitPlugins
+}
+
+// Data returns a pointer to PluginData.
+func (r *DefaultPluginSet) Data() *plugins.PluginData {
+	return r.data
+}
+
+// NewDefaultPluginSet initializes default plugin set and returns its pointer.
+func NewDefaultPluginSet(ctx *plugins.PluginContext, schedulerCache *cache.Cache) *DefaultPluginSet {
+	defaultRegistrar := DefaultPluginSet{
+		data: &plugins.PluginData{
+			Ctx:            ctx,
+			SchedulerCache: schedulerCache,
+		},
+	}
+	defaultRegistrar.registerReservePlugins()
+	defaultRegistrar.registerPrebindPlugins()
+	defaultRegistrar.registerPermitPlugins()
+	return &defaultRegistrar
+}
+
+func (r *DefaultPluginSet) registerReservePlugins() {
+	r.reservePlugins = []plugins.ReservePlugin{
+		// Init functions of all reserve plugins go here. They are called in the
+		// same order that they are registered.
+		// Example:
+		// examples.NewStatefulMultipointExample(map[int]string{1: "test1", 2: "test2"}),
+	}
+}
+
+func (r *DefaultPluginSet) registerPrebindPlugins() {
+	r.prebindPlugins = []plugins.PrebindPlugin{
+		// Init functions of all prebind plugins go here. They are called in the
+		// same order that they are registered.
+		// Example:
+		// examples.NewStatelessPrebindExample(),
+	}
+}
+
+func (r *DefaultPluginSet) registerPermitPlugins() {
+	r.permitPlugins = []plugins.PermitPlugin{
+		// Init functions of all permit plugins go here. They are called in the
+		// same order that they are registered.
+		// Example:
+		// examples.NewGangSchedulingPlugin(60),
+	}
+}

--- a/pkg/scheduler/plugins/registrar.go
+++ b/pkg/scheduler/plugins/registrar.go
@@ -17,7 +17,9 @@ limitations under the License.
 package plugins
 
 import (
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	"k8s.io/kubernetes/pkg/scheduler/plugins/examples"
 	plugins "k8s.io/kubernetes/pkg/scheduler/plugins/v1alpha1"
 )
 
@@ -52,11 +54,12 @@ func (r *DefaultPluginSet) Data() *plugins.PluginData {
 }
 
 // NewDefaultPluginSet initializes default plugin set and returns its pointer.
-func NewDefaultPluginSet(ctx *plugins.PluginContext, schedulerCache *cache.Cache) *DefaultPluginSet {
+func NewDefaultPluginSet(ctx *plugins.PluginContext, schedulerCache *cache.Cache, client clientset.Interface) *DefaultPluginSet {
 	defaultRegistrar := DefaultPluginSet{
 		data: &plugins.PluginData{
 			Ctx:            ctx,
 			SchedulerCache: schedulerCache,
+			Client:         client,
 		},
 	}
 	defaultRegistrar.registerReservePlugins()
@@ -88,6 +91,7 @@ func (r *DefaultPluginSet) registerPermitPlugins() {
 		// Init functions of all permit plugins go here. They are called in the
 		// same order that they are registered.
 		// Example:
-		// examples.NewGangSchedulingPlugin(60),
+		// examples.NewStatelessPrebindExample(),
+		examples.NewGangSchedulingPlugin(60),
 	}
 }

--- a/pkg/scheduler/plugins/v1alpha1/interface.go
+++ b/pkg/scheduler/plugins/v1alpha1/interface.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
 
@@ -27,6 +28,7 @@ import (
 type PluginData struct {
 	Ctx            *PluginContext
 	SchedulerCache *cache.Cache
+	Client         clientset.Interface
 	// We may want to add the scheduling queue here too.
 }
 

--- a/pkg/scheduler/plugins/v1alpha1/interface.go
+++ b/pkg/scheduler/plugins/v1alpha1/interface.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file defines the scheduling framework plugin interfaces.
+
+package v1alpha1
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
+)
+
+// PluginData carries information that plugins may need.
+type PluginData struct {
+	Ctx            *PluginContext
+	SchedulerCache *cache.Cache
+	// We may want to add the scheduling queue here too.
+}
+
+// Plugin is the parent type for all the scheduling framework plugins.
+type Plugin interface {
+	Name() string
+}
+
+// ReservePlugin is an interface for Reserve plugins. These plugins are called
+// at the reservation point, AKA "assume". These are meant to updated the state
+// of the plugin. They do not return any value (other than error).
+type ReservePlugin interface {
+	Plugin
+	// Reserve is called by the scheduling framework when the scheduler cache is
+	// updated.
+	Reserve(ps PluginSet, p *v1.Pod, nodeName string) error
+}
+
+// PrebindPlugin is an interface that must be implemented by "prebind" plugins.
+// These plugins are called before a pod being scheduled
+type PrebindPlugin interface {
+	Plugin
+	// Prebind is called before binding a pod. All prebind plugins must return
+	// or the pod will not be sent for binding.
+	Prebind(ps PluginSet, p *v1.Pod, nodeName string) (bool, error)
+}
+
+// PermitPlugin is an interface that must be implemented by "permit" plugins.
+// These plugins are called before a pod being scheduled
+type PermitPlugin interface {
+	Plugin
+	// Permit is called before calling pre-bind on a pod.
+	Permit(ps PluginSet, p *v1.Pod, nodeName string) (bool, error)
+	// ShouldReject returns whether the pod should be rejected
+	ShouldReject(ps PluginSet, p *v1.Pod) (bool, error)
+	// ShouldWait returns whether the pod should wait
+	ShouldWait(ps PluginSet, p *v1.Pod) (bool, error)
+	// ShouldAccept specifies whether the pod should be accepted
+	ShouldAccept(ps PluginSet, p *v1.Pod) (bool, error)
+}
+
+// PluginSet registers plugins used by the scheduling framework.
+// The plugins registered are called at specified points in an scheduling cycle.
+type PluginSet interface {
+	Data() *PluginData
+	ReservePlugins() []ReservePlugin
+	PrebindPlugins() []PrebindPlugin
+	PermitPlugins() []PermitPlugin
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does**:
This PR adds the an example for gang scheduling pods in a job using the Permit API.

**For Testing**: 
A sample job spec:
```
apiVersion: batch/v1
kind: Job
metadata:
  name: pi
  annotations:
   k8s.gang.io: "true"
spec:
  template:
    spec:
      tolerations:
      - key: node.kubernetes.io/unreachable
        effect: NoSchedule
      containers:
      - name: pi
        image: ubuntu:16.04
        command: ["sleep", "10s"]
        resources:
          requests:
            cpu: 8
            memory: 128Mi
      restartPolicy: Never
  parallelism: 5
  completions: 5
```
The annotation `k8s.gang.io: "true"` is used to indicate whether this job should be scheduled as a gang. In the above job spec, 5 pods constitute a gang.

**Limitations**:
In the current implementation, `parallelism` and `completions` should be the same for the gang scheduling to work properly and one option could be to handle that at admission time.